### PR TITLE
Bugfix- Center loader spinner

### DIFF
--- a/src/components/Chat/MessageList.js
+++ b/src/components/Chat/MessageList.js
@@ -1,5 +1,6 @@
 import React, { useState, useRef, useEffect } from 'react';
 import styled from 'styled-components';
+import Loader from 'react-loader-spinner';
 
 const StyledMessageList = styled.div`
   flex: 1;
@@ -60,7 +61,8 @@ const MessageList = ({ messages, userId }) => {
   return (
     <StyledMessageList>
       <ul className='ul'>
-        {messages &&
+        {messages ? (
+          messages &&
           messages.map((message, index) => (
             <li
               key={index}
@@ -77,7 +79,15 @@ const MessageList = ({ messages, userId }) => {
               </div>
               <p className='message'>{message.text}</p>
             </li>
-          ))}
+          ))
+        ) : (
+          <Loader
+            type='TailSpin'
+            color='#2BAD60'
+            height={50}
+            width={50}
+          />
+        )}
       </ul>
       <div ref={messagesEndRef}></div>
     </StyledMessageList>

--- a/src/components/Chat/UserList.js
+++ b/src/components/Chat/UserList.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import uuid from 'uuid';
 import styled from 'styled-components';
+import Loader from 'react-loader-spinner';
 
 const UserListStyle = styled.div`
   position: static;
@@ -31,7 +32,8 @@ const UserList = props => {
 
   return (
     <>
-      {rooms &&
+      {rooms ? (
+        rooms &&
         rooms.map(room => (
           <UserListStyle
             key={uuid()}
@@ -48,7 +50,15 @@ const UserList = props => {
               }
             />
           </UserListStyle>
-        ))}
+        ))
+      ) : (
+        <Loader
+          type='TailSpin'
+          color='#2BAD60'
+          height={50}
+          width={50}
+        />
+      )}
     </>
   );
 };

--- a/src/views/Feedback/Feedback.js
+++ b/src/views/Feedback/Feedback.js
@@ -44,6 +44,7 @@ const StyledFeedback = styled.div`
 
   .loaderStyled {
     margin-top: 20vh;
+    margin-left: -17rem;
   }
 
   .chart-container {

--- a/src/views/Marketplace/Marketplace.js
+++ b/src/views/Marketplace/Marketplace.js
@@ -59,7 +59,6 @@ const StyledMarketplace = styled.div`
   }
   .loaderStyled {
     margin-top: 200px;
-    margin-left: 35rem;
     margin-bottom: 200px;
   }
 `;

--- a/src/views/UserDashboard/UserDashboard.js
+++ b/src/views/UserDashboard/UserDashboard.js
@@ -134,7 +134,6 @@ const DashboardContainer = styled.div`
   }
 
   .loaderStyled {
-    margin-left: 30rem;
     margin-top: 20vh;
   }
 `;


### PR DESCRIPTION
##  What does this PR do
Centers loader spinner

##  Description of the task to be completed
Center loader spinner on affected components
Adds loader spinner to the user list of chat component

##  How should this manually be tested
npm start the project

##  What are the relevant Trello board stories
React-Loader-Spinner is not centered anymore

##  Screenshots (If appropriate)


##  Questions (If any): 